### PR TITLE
Fix crash in model download cleanup

### DIFF
--- a/main.py
+++ b/main.py
@@ -2086,9 +2086,13 @@ def download_yolo_model(model_name, url=None, disable_ssl_verify=False):
     
     except Exception as e:
         # Clean up any partially downloaded file if an unexpected error occurred
-        if os.path.exists(model_path) and "downloaded successfully" not in OutputManager.info[-1]:
-             try: os.remove(model_path) 
-             except: pass
+        if os.path.exists(model_path):
+            last_info = OutputManager.info[-1] if OutputManager.info else ""
+            if "downloaded successfully" not in last_info:
+                try:
+                    os.remove(model_path)
+                except Exception:
+                    pass
         
         # Log the error and re-raise
         OutputManager.log(f"Failed to download {model_name}: {str(e)}", "FATAL")


### PR DESCRIPTION
## Summary
- avoid IndexError when cleaning up failed model downloads

## Testing
- `python -m py_compile main.py camera.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6841176df8b883238f51dcb1a15499ff