### PR TITLE
Fix cleanup logic for partially downloaded models

### DIFF
--- a/main.py
+++ b/main.py
@@ -2086,13 +2086,12 @@ def download_yolo_model(model_name, url=None, disable_ssl_verify=False):
     
     except Exception as e:
         # Clean up any partially downloaded file if an unexpected error occurred
-        if os.path.exists(model_path):
-            last_info = OutputManager.info[-1] if OutputManager.info else ""
-            if "downloaded successfully" not in last_info:
-                try:
-                    os.remove(model_path)
-                except Exception:
-                    pass
+        if os.path.exists(model_path) and OutputManager.info and \
+           "downloaded successfully" not in OutputManager.info[-1]:
+            try:
+                os.remove(model_path)
+            except Exception:
+                pass
         
         # Log the error and re-raise
         OutputManager.log(f"Failed to download {model_name}: {str(e)}", "FATAL")


### PR DESCRIPTION
## Summary
- adjust cleanup condition for failed model downloads

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68411f192cec8323800c4a756f2fbc49