### PR TITLE
Add tests for validate_resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ python main.py
 ```bash
 python main.py --no-camera
 ```
+5. Run the test suite:
+
+```bash
+pytest
+```
+
 
 ## Configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ ultralytics>=8.0.0
 tqdm>=4.41.0
 Pillow>=8.0.0
 matplotlib>=3.3.0
+pytest>=7.0.0
 
 # Camera (only if running Python <3.9, otherwise skip or use apt for picamera2)
 picamera>=1.13; python_version < "3.9"

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,19 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import camera
+
+def test_validate_resolution_valid():
+    assert camera.validate_resolution(640, 480) == (640, 480)
+    assert camera.validate_resolution("1024", "768") == (1024, 768)
+
+
+def test_validate_resolution_invalid_defaults_to_hd():
+    assert camera.validate_resolution("abc", "def") == camera.DEFAULT_RESOLUTION
+    assert camera.validate_resolution(None, None) == camera.DEFAULT_RESOLUTION
+
+
+def test_validate_resolution_below_minimum():
+    assert camera.validate_resolution(50, 50) == (160, 120)
+    assert camera.validate_resolution(159, 130) == (160, 120)
+    assert camera.validate_resolution(200, 100) == (160, 120)
+


### PR DESCRIPTION
## Summary
- add pytest to requirements
- document test suite in README
- create tests for `validate_resolution` covering valid, invalid, and minimum resolution cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411f0b2a6c8323bd94c41ea6ef8270