### PR TITLE
Add API parameter usage examples

### DIFF
--- a/API.md
+++ b/API.md
@@ -59,6 +59,18 @@ Example response:
 }
 ```
 
+Example request with an image path:
+
+```bash
+curl "http://127.0.0.1:8000/courts?image_path=images/input.png"
+```
+
+Example request using the camera:
+
+```bash
+curl "http://127.0.0.1:8000/courts?use_camera=true"
+```
+
 During automated tests the endpoint returns simplified dummy data to avoid running the heavy computer vision pipeline. This happens when the environment variable `TESTING` is set to `1`.
 
 ### `GET /status`
@@ -74,6 +86,12 @@ Retrieve basic status information about the host device and camera. This is usef
 - `camera_available` – `true` if a supported camera module is detected.
 - `camera_version` – `1` for legacy Picamera, `2` for Picamera2, or `null` if no camera libraries are available.
 
+Example request:
+
+```bash
+curl "http://127.0.0.1:8000/status"
+```
+
 ### `GET /court_count`
 
 Return only the number of tennis courts detected in the provided image or from the camera.
@@ -86,6 +104,18 @@ Return only the number of tennis courts detected in the provided image or from t
 #### Response JSON
 
 - `total_courts` – Number of detected courts.
+
+Example request specifying an image path:
+
+```bash
+curl "http://127.0.0.1:8000/court_count?image_path=images/input.png"
+```
+
+Example request using the camera:
+
+```bash
+curl "http://127.0.0.1:8000/court_count?use_camera=true"
+```
 
 ## Usage examples
 


### PR DESCRIPTION
## Summary
- provide explicit request examples in `API.md`
- show how to call each endpoint with query parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843a5cbf0d083238863bb9fae3ae1c3