### PR TITLE
Improve API photo handling

### DIFF
--- a/API.md
+++ b/API.md
@@ -37,11 +37,14 @@ Analyze an image and return statistics about the detected courts and players.
 
 - `image_path` *(optional)* – Path to the image file to analyze. If omitted, the
   default input path from `config.json` (`images/input.png` by default) is used.
+  The API also stores an annotated result image alongside the original using a
+  timestamped filename inside the `images/` directory.
 - `use_camera` *(optional)* – Capture a new image using the Raspberry Pi camera
   instead of providing a path. When this flag is enabled the API tries to take a
   photo at the resolution specified under the `Camera` section of `config.json`.
-  The captured image is saved to `api_captures/capture.png` before analysis. If
-  no camera is detected the endpoint returns HTTP 400 with `"No camera detected"`.
+  The captured photo is written to `images/capture_YYYYMMDD_HHMMSS.png` and the
+  processed output to `images/result_YYYYMMDD_HHMMSS.png`. If no camera is
+  detected the endpoint returns HTTP 400 with `"No camera detected"`.
 
 #### Response JSON
 
@@ -58,6 +61,9 @@ Example response:
   "people_per_court": {"1": 2, "2": 2}
 }
 ```
+
+Each request also appends a record of the input and output file paths to
+`api_captures/log.txt` so you can review how the API was used over time.
 
 During automated tests the endpoint returns simplified dummy data to avoid running the heavy computer vision pipeline. This happens when the environment variable `TESTING` is set to `1`.
 
@@ -125,7 +131,8 @@ You can use the underlying logic without running the HTTP server:
 ```python
 from api import analyze_image
 
-result = analyze_image("images/input.png")
+# Optionally provide an output_path to save an annotated image
+result = analyze_image("images/input.png", output_path="images/example_result.png")
 print(result)
 ```
 

--- a/api.py
+++ b/api.py
@@ -3,14 +3,17 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import os
 import cv2
+import numpy as np
 from typing import Dict
+from datetime import datetime
 import camera as camera_module
 from main import (
     Config,
     detect_tennis_court,
     detect_people_ultralytics,
     analyze_people_positions_parallel,
-    download_yolo_model
+    download_yolo_model,
+    court_positions_defined,
 )
 
 app = FastAPI(title="Tennis Court Availability API",
@@ -39,7 +42,43 @@ class Status(BaseModel):
 class CourtCount(BaseModel):
     total_courts: int
 
-def analyze_image(image_path: str) -> CourtStatus:
+def _log_capture(input_path: str, output_path: str | None = None) -> None:
+    """Append a record of input/output images to api_captures/log.txt."""
+    if os.environ.get("TESTING"):
+        return
+    os.makedirs("api_captures", exist_ok=True)
+    log_path = os.path.join("api_captures", "log.txt")
+    timestamp = datetime.now().isoformat()
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(f"{timestamp}, {input_path}, {output_path or ''}\n")
+
+
+def _courts_from_saved_positions(image):
+    """Create court structures from Config.COURT_POSITIONS."""
+    height, width = image.shape[:2]
+    courts = []
+    for idx, court in enumerate(Config.COURT_POSITIONS):
+        pts = court.get("points", [])[:8]
+        if len(pts) < 4:
+            continue
+        pts_array = np.array(pts, dtype=np.int32)
+        approx = pts_array.reshape(-1, 1, 2)
+        mask = np.zeros((height, width), dtype=np.uint8)
+        cv2.fillPoly(mask, [pts_array], 255)
+        x, y, w, h = cv2.boundingRect(pts_array)
+        courts.append({
+            "court_number": idx + 1,
+            "approx": approx,
+            "bbox": (x, y, w, h),
+            "blue_mask": mask,
+            "green_mask": np.zeros((height, width), dtype=np.uint8),
+            "blue_ratio": 1.0,
+            "green_ratio": 0.0,
+        })
+    return courts
+
+
+def analyze_image(image_path: str, output_path: str | None = None) -> CourtStatus:
     """Detect courts and people in the given image."""
     # In test mode, return simplified data to avoid heavy processing
     if os.environ.get("TESTING"):
@@ -54,7 +93,12 @@ def analyze_image(image_path: str) -> CourtStatus:
     if image is None:
         raise FileNotFoundError(f"Image not found: {image_path}")
 
-    courts = detect_tennis_court(image)
+    if court_positions_defined():
+        courts = _courts_from_saved_positions(image)
+    else:
+        courts = detect_tennis_court(image)
+        for i, c in enumerate(courts):
+            c["court_number"] = i + 1
 
     model_path = download_yolo_model(Config.Model.NAME)
     if Config.Model.NAME.startswith("yolov8"):
@@ -67,6 +111,26 @@ def analyze_image(image_path: str) -> CourtStatus:
     people = detect_people_ultralytics(model, image, confidence=Config.Model.CONFIDENCE)
     locations = analyze_people_positions_parallel(people, courts)
 
+    if output_path:
+        out_img = image.copy()
+        for court in courts:
+            cv2.polylines(out_img, [court["approx"]], True, tuple(Config.Visual.COURT_OUTLINE_COLOR), Config.Visual.COURT_OUTLINE_THICKNESS)
+            if Config.Visual.SHOW_COURT_NUMBER:
+                x, y, w, h = court["bbox"]
+                cv2.putText(out_img, f"Court {court['court_number']}", (x + w // 2 - 40, y + h // 2), cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 255), 2)
+
+        for idx, person in enumerate(people):
+            x1, y1, x2, y2 = person["bbox"]
+            court_idx, area = locations[idx]
+            if court_idx >= 0:
+                color = Config.Visual.PERSON_IN_BOUNDS_COLOR if area == "in_bounds" else Config.Visual.PERSON_OUT_BOUNDS_COLOR
+            else:
+                color = Config.Visual.PERSON_OFF_COURT_COLOR
+            cv2.rectangle(out_img, (x1, y1), (x2, y2), tuple(color), 2)
+
+        cv2.imwrite(output_path, out_img)
+        _log_capture(image_path, output_path)
+
     people_per_court: Dict[int, int] = {}
     for (court_idx, area) in locations:
         if court_idx >= 0 and area == 'in_bounds':
@@ -75,44 +139,50 @@ def analyze_image(image_path: str) -> CourtStatus:
     return CourtStatus(
         total_courts=len(courts),
         total_people=len(people),
-        people_per_court=people_per_court
+        people_per_court=people_per_court,
     )
 
 @app.get("/courts", response_model=CourtStatus)
 def get_courts(image_path: str | None = None, use_camera: bool = False):
     """Return court and player statistics for the provided image or camera."""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     if use_camera:
-        capture_dir = "api_captures"
-        capture_file = "capture.png"
+        os.makedirs(Config.Paths.IMAGES_DIR, exist_ok=True)
+        input_file = f"capture_{timestamp}.png"
         success = camera_module.takePhoto(
-            output_dir=capture_dir,
-            output_filename=capture_file,
+            output_dir=Config.Paths.IMAGES_DIR,
+            output_filename=input_file,
             width=Config.Camera.WIDTH,
             height=Config.Camera.HEIGHT,
         )
         if not success:
             raise HTTPException(status_code=400, detail="No camera detected")
-        image_path = os.path.join(capture_dir, capture_file)
+        image_path = os.path.join(Config.Paths.IMAGES_DIR, input_file)
     elif image_path is None:
         image_path = Config.Paths.input_path()
-    return analyze_image(image_path)
+
+    output_file = f"result_{timestamp}.png"
+    output_path = os.path.join(Config.Paths.IMAGES_DIR, output_file)
+    return analyze_image(image_path, output_path=output_path)
 
 
 @app.get("/court_count", response_model=CourtCount)
 def get_court_count(image_path: str | None = None, use_camera: bool = False):
     """Return only the number of detected courts."""
     if use_camera:
-        capture_dir = "api_captures"
-        capture_file = "capture.png"
+        os.makedirs(Config.Paths.IMAGES_DIR, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        input_file = f"capture_{timestamp}.png"
         success = camera_module.takePhoto(
-            output_dir=capture_dir,
-            output_filename=capture_file,
+            output_dir=Config.Paths.IMAGES_DIR,
+            output_filename=input_file,
             width=Config.Camera.WIDTH,
             height=Config.Camera.HEIGHT,
         )
         if not success:
             raise HTTPException(status_code=400, detail="No camera detected")
-        image_path = os.path.join(capture_dir, capture_file)
+        image_path = os.path.join(Config.Paths.IMAGES_DIR, input_file)
+        _log_capture(image_path, None)
     elif image_path is None:
         image_path = Config.Paths.input_path()
 


### PR DESCRIPTION
## Summary
- log API captures and build courts from saved positions
- keep photos in `images` directory when capturing with camera
- generate annotated output images through the API
- document new image logging and optional `output_path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a168fd48832389b170a1f921a5d2